### PR TITLE
Fixed Non-deterministic behavior of testFromAfterAccumulate

### DIFF
--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/AccumulateTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/AccumulateTest.java
@@ -2108,7 +2108,7 @@ public class AccumulateTest extends BaseModelTest {
                 "import " + Person.class.getCanonicalName() + ";\n" +
                 "rule R when\n" +
                 "  $persons : List( size > 0 ) from collect ( Person() )\n" +
-                "  Person( $age : age, $name : name ) from $persons\n" +
+                "  Person( $age : getAge(), $name : getName() ) from $persons\n" +
                 "then\n" +
                 "  System.out.println($name + \"' is \" + $age);\n" +
                 "end";

--- a/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/AccumulateTest.java
+++ b/drools-model/drools-model-codegen/src/test/java/org/drools/model/codegen/execmodel/AccumulateTest.java
@@ -2108,9 +2108,9 @@ public class AccumulateTest extends BaseModelTest {
                 "import " + Person.class.getCanonicalName() + ";\n" +
                 "rule R when\n" +
                 "  $persons : List( size > 0 ) from collect ( Person() )\n" +
-                "  Person( $age : getAge(), $name : getName() ) from $persons\n" +
+                "  $person : Person() from $persons\n" +
                 "then\n" +
-                "  System.out.println($name + \"' is \" + $age);\n" +
+                "  System.out.println($person.getName() + \"' is \" + $person.getAge());\n" +
                 "end";
 
         KieSession ksession = getKieSession(str);


### PR DESCRIPTION
### Pull Request Description

#### Report
**Issue:**
In testing the testFromAfterAccumulate method, we encountered a problem with the Drools rule string that uses the pattern Person( $age : age, $name : name ) from $persons. Occasionally, the value mapping for arguments, specifically <String, Integer>, does not work as expected.

**How to replicate and retest**
The above mentioned issue is found using the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool.
1. Clone the repository:
`https://github.com/apache/incubator-kie-drools/tree/main`
2. Compile the `drools-model/drools-model-codegen` module:
`mvn clean install -lp drools-model/drools-model-codegen -am -DskipTests
`
3. (Optional) Run the unit test:
`mvn -lp drools-model/drools-model-codegen test -Dtest=org.drools.model.codegen.execmodel.AccumulateTest#testFromAfterAccumulate
`
4. Run the unit test using NonDex:
`
mvn -lp drools-model/drools-model-codegen  test  edu.illinois:nondex-maven-plugin:2.1.7  -Dtest=org.drools.model.codegen.execmodel.AccumulateTest#testFromAfterAccumulate
`

**Error:**
The above steps reveal the following failed test:
```
The method execute(Block2<String,Integer>) in the type ConsequenceBuilder._2<String,Integer> is not applicable for the arguments (LambdaConsequence73FEAF6BE6E0F73F2D5CB31A68053C1E)
```


#### Solution
In Drools, pattern matching may encounter issues when extracting fields if they are not easily accessible. Specifically, when using the pattern Person( $age : age, $name : name ), Drools attempts to map the fields age and name to the corresponding properties directly. 

To ensure that Drools correctly matches and extracts the field values, it is more reliable to use getter methods in the pattern, such as getAge() and getName(). This approach leverages the publicly accessible getter methods to retrieve private field values.
